### PR TITLE
adds requirements file to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 *.zip
 *.pyc
+venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# base game
+pyqt5
+
+# training models
+stable_baselines3
+pygame


### PR DESCRIPTION
Adds a requirements file to the repo for ease of building virtual environments to run code. Note - packages are not pinned so issues may arise. Also, directly installing `pytorch` rather than allowing `stable_baselines3` may be beneficial as then you can specify which `cuda` package you would like.